### PR TITLE
Added headers property to amqp_params

### DIFF
--- a/include/couchbeam.hrl
+++ b/include/couchbeam.hrl
@@ -29,7 +29,8 @@
     password    = nil :: string(),
     name        = default :: term(),
     timeout     = infinity :: integer() | infinity,
-    max_dbs_open = 100
+    max_dbs_open = 100 :: integer(),
+		headers     = [] :: headers()
 }).
 
 -record(server, {

--- a/src/couchbeam_resource.erl
+++ b/src/couchbeam_resource.erl
@@ -69,9 +69,9 @@ request(State, Method, Path, Headers, Params, Body, Options) ->
     end.
     
 
-do_request(#couchdb_params{host=Host, port=Port, ssl=Ssl, timeout=Timeout},
+do_request(#couchdb_params{host=Host, port=Port, ssl=Ssl, timeout=Timeout, headers=DefaultHeaders},
         Method, Path, Headers, {BodyFun, InitialBody}, Options) ->
-    case lhttpc:request(Host, Port, Ssl, Path, Method, Headers, InitialBody, Timeout, Options) of
+    case lhttpc:request(Host, Port, Ssl, Path, Method, Headers ++ DefaultHeaders, InitialBody, Timeout, Options) of
         {ok, {{StatusCode, ReasonPhrase}, ResponseHeaders, ResponseBody}} ->
             State = #response{method    = Method,
                               status    = StatusCode,


### PR DESCRIPTION
I patched couchbeam to accept a headers parameter when starting a connection so code in web apps can pass an authentication cookie by specifying headers=[{"Cookie","AuthSession=lkjalksdjfkajsdjf"}] in #amqp_params. This allows server-side code to act with the permissions of the currently-logged in user.
