### PR TITLE
application:start() doesn't really start couchbeam

### DIFF
--- a/src/couchbeam_app.erl
+++ b/src/couchbeam_app.erl
@@ -16,8 +16,7 @@
 %%          {error, Reason}   
 %%--------------------------------------------------------------------
 start(_Type, _StartArgs) ->
-    couchbeam_deps:ensure(),
-    couchbeam_sup:start_link().
+    couchbeam:start().
 
 %%--------------------------------------------------------------------
 %% Func: stop/1


### PR DESCRIPTION
I made that small change to make sure the application is started the right way.
I stumbled upon that problem when I tried to integrate couchbeam into another application.
