### PR TITLE
Fix typo in couchbeam:save_docs/3

### DIFF
--- a/src/couchbeam.erl
+++ b/src/couchbeam.erl
@@ -469,7 +469,7 @@ save_docs(#db{server=Server, options=IbrowseOpts}=Db, Docs, Options) ->
     {Options2, Body} = case couchbeam_util:get_value("all_or_nothing", 
             Options1, false) of
         true ->
-            Body1 = couchbeam:json_encode({[
+            Body1 = couchbeam_util:json_encode({[
                 {<<"all_or_nothing">>, true},
                 {<<"docs">>, Docs1}
             ]}),


### PR DESCRIPTION
In couchbeam:save_docs/3 a call is made to couchbeam:json_encode/1 rather than couchbeam_util:json_encode/1.
