### PR TITLE
Any tuple of strings can be used as an argument when querying for changes

### DIFF
--- a/src/couchbeam_changes.erl
+++ b/src/couchbeam_changes.erl
@@ -191,6 +191,10 @@ parse_changes_options([{style, Style}|Rest], #changes_args{http_options=Opts} = 
 parse_changes_options([descending|Rest], #changes_args{http_options=Opts} = Args) ->
     Opts1 = [{"descending", "true"}|Opts],
     parse_changes_options(Rest, Args#changes_args{http_options=Opts1});
+parse_changes_options([{Key, Val}|Rest], #changes_args{http_options=Opts} = Args)
+  when is_list(Key) andalso is_list(Val) ->
+    Opts1 = [{Key, Val}|Opts],
+    parse_changes_options(Rest, Args#changes_args{http_options=Opts1});
 parse_changes_options([_|Rest], Args) ->
     parse_changes_options(Rest, Args).
 


### PR DESCRIPTION
Any tuple of strings can be used as an argument when querying for changes. Query arguments can be used in the javascipt in the filter. Search for "We can make the filter function using a request parameter:" here: http://guide.couchdb.org/draft/notifications.html
