### PR TITLE
header path update for ibrowse

### DIFF
--- a/src/couchbeam_changes.erl
+++ b/src/couchbeam_changes.erl
@@ -6,7 +6,7 @@
 -module(couchbeam_changes).
 
 -include("couchbeam.hrl").
--include_lib("ibrowse/src/ibrowse.hrl").
+-include_lib("ibrowse/include/ibrowse.hrl").
 
 -export([stream/2, stream/3,
          fetch/1, fetch/2,

--- a/src/couchbeam_httpc.erl
+++ b/src/couchbeam_httpc.erl
@@ -5,7 +5,7 @@
 
 -module(couchbeam_httpc).
 
--include_lib("ibrowse/src/ibrowse.hrl").
+-include_lib("ibrowse/include/ibrowse.hrl").
 
 -export([request/4, request/5, request/6,
         request_stream/4, request_stream/5, request_stream/6,


### PR DESCRIPTION
The header paths in ibrowse, as of Mar 26, are correctly located in ./include/ rather than ./src/ .
