### PR TITLE
Fix typo in docs (commit f7eac37) 

### DIFF
--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -341,7 +341,7 @@ Port = 5984,
 Prefix = "",
 UserName = "guest", 
 Password = "test",
-Options = [{basic_auth, {UserName, Password}],
+Options = [{basic_auth, {UserName, Password}}],
 S1 = couchbeam:server_connection(Host, Port, Prefix, Options).
 '''
 


### PR DESCRIPTION
Fix typo in docs (commit f7eac37) 
