### PR TITLE
Allow couchbeam_doc:extend/2 to merge 2 documents.

### DIFF
--- a/src/couchbeam_doc.erl
+++ b/src/couchbeam_doc.erl
@@ -81,9 +81,11 @@ extend(Key, Value, JsonObj) ->
 
 %% @spec extend(Prop::property(), JsonObj::json_obj()) -> json_obj()
 %% @type property() = json_obj() | tuple()
-%% @doc extend a jsonobject by a property or list of property
+%% @doc extend a jsonobject by a property, list of property or another jsonobject
 extend([], JsonObj) ->
     JsonObj;
+extend({List}, JsonObj) when is_list(List)  ->
+    extend(List, JsonObj);
 extend([Prop|R], JsonObj)->
     NewObj = extend(Prop, JsonObj),
     extend(R, NewObj);


### PR DESCRIPTION
Convenient when merging for example an incoming JSON request into a document.
