### PR TITLE
Jiffy updated to more supported version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
                         "HEAD"}},
 
     %% ejson for JSON and header parsing
-    {jiffy, ".*", {git,"https://github.com/refuge/jiffy.git",
+    {jiffy, ".*", {git,"https://github.com/davisp/jiffy.git",
                   "master"}},
 
     %% erlang-oauth for oauth authentification


### PR DESCRIPTION
Ols version of jiffy cannot be compiled with gcc-4.8. Dependency updated to more resent version.
