### PR TITLE
support for couchdb lists

### DIFF
--- a/include/couchbeam.hrl
+++ b/include/couchbeam.hrl
@@ -81,6 +81,7 @@
 
 -record(view_query_args, {
         method = get :: atom(),
+        mode = views :: atom(),
         options = [] :: view_options(),
         keys = [] :: list(binary())}).
 


### PR DESCRIPTION
Hello Benoit,

Here is a patch to add support for couchdb lists. 

HTTP API:  curl -X GET http://Database URL>/_design/Design/_list/List/View

Usage:  couchbeam_view:fetch(Db, {Design, List, View}, []).