### PR TITLE
Point to mochiweb master instead of HEAD.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 
 {deps, [
     {mochiweb, ".*", {git,"https://github.com/mochi/mochiweb.git",
-                        "HEAD"}},
+                        "master"}},
 
     %% ejson for JSON and header parsing
     {jiffy, ".*", {git,"https://github.com/refuge/jiffy.git",


### PR DESCRIPTION
This worked fine for me locally but there was an RPC error when deploying it. The git version on my remote server is quite a bit older than the one I'm using locally. That's probably why it fails. I'm submitting this pull request because it seems like an typo to me.
