### PR TITLE
Fix calls to nonexistent functions

### DIFF
--- a/src/couchbeam_util.erl
+++ b/src/couchbeam_util.erl
@@ -90,9 +90,9 @@ oauth_header(Url, Action, OauthProps) ->
         put -> "PUT";
         head -> "HEAD"
     end,
-    Params = oauth:signed_params(Method, Url, QSL, Consumer, Token, TokenSecret)
+    Params = oauth:sign(Method, Url, QSL, Consumer, Token, TokenSecret)
     -- QSL,
-    {"Authorization", "OAuth " ++ oauth_uri:params_to_header_string(Params)}.
+    {"Authorization", "OAuth " ++ oauth:header_params_encode(Params)}.
 
 
 %% @doc merge 2 proplists. All the Key - Value pairs from both proplists


### PR DESCRIPTION
Refactorings in the erlang-oauth dependency broke
`couchbeam_util:oauth_header/3`, as the called functions aren't
available anymore.

For reference, here the "breaking change" in erlang-oauth:

https://github.com/tim/erlang-oauth/commit/fc5f528cea05b6b0b5e3ace0300268a330b01ac6
