### PR TITLE
Switch deps to use git:// instead of https:// for compatibiity reasons

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,18 +5,18 @@
     ]}.
 
 {deps, [
-    {mochiweb, ".*", {git,"https://github.com/mochi/mochiweb.git",
+    {mochiweb, ".*", {git,"git://github.com/mochi/mochiweb.git",
                       "v2.7.0"}},
 
     %% ejson for JSON and header parsing
-    {jiffy, ".*", {git,"https://github.com/davisp/jiffy.git",
+    {jiffy, ".*", {git,"git://github.com/davisp/jiffy.git",
                    "0.8.5"}},
 
     %% erlang-oauth for oauth authentification
-    {oauth, ".*", {git,"https://github.com/refuge/erlang-oauth.git",
+    {oauth, ".*", {git,"git://github.com/refuge/erlang-oauth.git",
                    "master"}},
 
     %% ibrowse for doing HTTP requests
-    {ibrowse, ".*", {git, "https://github.com/cmullaparthi/ibrowse.git",
+    {ibrowse, ".*", {git, "git://github.com/cmullaparthi/ibrowse.git",
                      "v4.0.2"}}
 ]}.


### PR DESCRIPTION
Using git:// instead of https:// seems to be the more accepted convention and also Heroku is not able to connect to https links when building deployments.
