### PR TITLE
add the couchbeam:set_values/2 function.

### DIFF
--- a/src/couchbeam_doc.erl
+++ b/src/couchbeam_doc.erl
@@ -9,7 +9,8 @@
 
 -export([set_value/3, get_value/2, get_value/3,
          take_value/2, take_value/3,
-         delete_value/2, extend/2, extend/3]).
+         delete_value/2, extend/2, extend/3,
+         set_values/2]).
 -export([get_id/1, get_rev/1, get_idrev/1, is_saved/1]).
 
 %% @spec get_id(Doc::json_obj()) -> binary()
@@ -48,6 +49,15 @@ set_value(Key, Value, JsonObj) when is_binary(Key) ->
         true -> set_value1(Props, Key, Value, []);
         false-> {lists:reverse([{Key, Value}|lists:reverse(Props)])}
     end.
+
+%% @spec set_values(List, JsonObj::json_obj()) -> term()
+%% @doc set the values of a list of tuples into the jsonobj.
+set_values([], JsonObj) ->
+    JsonObj;
+set_values([Head|Tail], JsonObj) ->
+    {Key, Value} = Head,
+    NewJsonObj = set_value(Key, Value, JsonObj),
+    set_values(Tail, NewJsonObj).
 
 %% @spec get_value(Key::key_val(), JsonObj::json_obj()) -> term()
 %% @type key_val() = lis() | binary()


### PR DESCRIPTION
With this function, instead of using several times the same function to add some fields to a document, we can use set_values.

Instead of using couchbeam_doc:set_value/3

``` erlang
Doc = {[{<<"content">>, <<"this is a funny doc">>}]}.
Doc1 = couchbeam_doc:set_value(<<"active">>, true, Doc).
Doc2 = couchbeam_doc:set_value(<<"type">>, <<"user">>, Doc1).
```

You can use couchbeam_doc:set_values/2
Example:

``` erlang
1> Doc = {[{<<"content">>, <<"this is a funny doc">>}]}.
{[{<<"content">>,<<"this is a funny doc">>}]}
2> couchbeam_doc:set_values([{<<"active">>, true}], Doc).
{[{<<"content">>,<<"this is a funny doc">>},{<<"active">>,true}]}
3> couchbeam_doc:set_values([{<<"active">>, true}], Doc).
{[{<<"content">>,<<"this is a funny doc">>},{<<"active">>,true}]}
4> couchbeam_doc:set_values([{<<"active">>, true}, {<<"type">>, <<"user">>}], Doc).
{[{<<"content">>,<<"this is a funny doc">>},
  {<<"active">>,true},
  {<<"type">>,<<"user">>}]}
```
