### PR TITLE
#114 Fix; couchbeam:reply_att/1 handles 200 & 201 as success

### DIFF
--- a/src/couchbeam.erl
+++ b/src/couchbeam.erl
@@ -1094,7 +1094,7 @@ reply_att({ok, 404, _, Ref}) ->
 reply_att({ok, 409, _, Ref}) ->
     hackney:skip_body(Ref),
     {error, conflict};
-reply_att({ok, Status, _, Ref}) when Status >= 200 andalso Status < 300 ->
+reply_att({ok, Status, _, Ref}) when Status =:= 200 orelse Status =:= 201 ->
   {[{<<"ok">>, true}|R]} = couchbeam_httpc:json_body(Ref),
   {ok, {R}};
 reply_att({ok, Status, Headers, Ref}) ->


### PR DESCRIPTION
CouchDB upon the end of streaming, send 201 as success. Couchbeam should handle such cases as success.
So the following part:

```
reply_att({ok, 200, _, Ref}) ->
    {[{<<"ok">>, true}|R]} = couchbeam_httpc:json_body(Ref),
            {ok, {R}};
```

Becomes:

```
reply_att({ok, Status, _, Ref}) when Status >= 200 andalso Status < 300 ->
  {[{<<"ok">>, true}|R]} = couchbeam_httpc:json_body(Ref),
  {ok, {R}};
```

Maybe a the same should be applied on 30x & 10x responses?

Cheers.
