### PR TITLE
Fix Content-Type missing in HTTP Post

### DIFF
--- a/src/couchbeam_changes.erl
+++ b/src/couchbeam_changes.erl
@@ -227,7 +227,8 @@ changes_request(#db{server=Server, options=ConnOptions}=Db, Options) ->
                                        [200, 202]);
         _ ->
             Body =  couchbeam_ejson:encode({[{<<"doc_ids">>, DocIds}]}),
-            couchbeam_httpc:db_request(post, Url, [], Body, ConnOptions,
+            Headers = [{<<"Content-Type">>, <<"application/json">>}],
+            couchbeam_httpc:db_request(post, Url, Headers, Body, ConnOptions,
                                        [200, 202])
     end,
 

--- a/src/couchbeam_changes_stream.erl
+++ b/src/couchbeam_changes_stream.erl
@@ -129,7 +129,8 @@ do_init_stream(#state{mref=MRef,
             hackney:request(get, Url, [], <<>>, ConnOpts1);
         DocIds ->
             Body =  couchbeam_ejson:encode({[{<<"doc_ids">>, DocIds}]}),
-            hackney:request(post, Url, [], Body, ConnOpts1)
+            Headers = [{<<"Content-Type">>, <<"application/json">>}],
+            hackney:request(post, Url, Headers, Body, ConnOpts1)
     end,
     receive
         {'DOWN', MRef, _, _, _} ->

--- a/src/couchbeam_view_stream.erl
+++ b/src/couchbeam_view_stream.erl
@@ -92,7 +92,8 @@ do_init_stream({#db{options=Opts}, Url, Args}, #state{mref=MRef}=State) ->
         post ->
             Body = couchbeam_ejson:encode({[{<<"keys">>,
                                              Args#view_query_args.keys}]}),
-            hackney:request(post, Url, [], Body, FinalOpts)
+            Headers = [{<<"Content-Type">>, <<"application/json">>}],
+            hackney:request(post, Url, Headers, Body, FinalOpts)
     end,
 
     case Reply of


### PR DESCRIPTION
Add Content-Type header for 3 post requests using JSON as body content.