### PR TITLE
couchbeam:db_exists/2 was failing

### DIFF
--- a/src/couchbeam.erl
+++ b/src/couchbeam.erl
@@ -303,6 +303,8 @@ all_dbs(#server{url=ServerUrl, options=Opts}) ->
 db_exists(#server{url=ServerUrl, options=Opts}, DbName) ->
     Url = hackney_url:make_url(ServerUrl, dbname(DbName), []),
     case couchbeam_httpc:db_request(head, Url, [], <<>>, Opts, [200]) of
+        {ok, 200, _}->
+            true;
         {ok, 200, _, _}->
             true;
         _Error ->

--- a/src/couchbeam.erl
+++ b/src/couchbeam.erl
@@ -303,7 +303,7 @@ all_dbs(#server{url=ServerUrl, options=Opts}) ->
 db_exists(#server{url=ServerUrl, options=Opts}, DbName) ->
     Url = hackney_url:make_url(ServerUrl, dbname(DbName), []),
     case couchbeam_httpc:db_request(head, Url, [], <<>>, Opts, [200]) of
-        {ok, 200, _}->
+        {ok, 200, _, _}->
             true;
         _Error ->
             false


### PR DESCRIPTION
In `couchbeam:db_exists/2`, `couchbeam_httpc:db_request/6` is returning a tuple of 4 `{ok, Status, Server Resp}` instead of a tuple of 3 that was expecting. So db_exist was always returning `false`.