### PR TITLE
NEWS link should point to NEWS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ the changes in a db or get all changes at once.
 
 The goal of Couchbeam is to ease the access to the Apache CouchDB and RCOUCH HTTP API in erlang.
 
-Read the [NEWS](https://raw.github.com/benoitc/couchbeam/master/NEWS) file
+Read the [NEWS](https://raw.github.com/benoitc/couchbeam/master/NEWS.md) file
 to get last changelog.
 
 ## Installation


### PR DESCRIPTION
Simple I know, but I doubt I will change much else -- though I am using it in an elixir env on ebeam so we shall see.