### PR TITLE
CouchDb 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ mime.types
 .rebar
 *.plt
 .rebar
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ mime.types
 .rebar
 *.plt
 .rebar
-.idea

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -5,7 +5,7 @@ Rebar2Deps = [
                  {tag,"2.8.0"}}},
 
     {hackney, ".*", {git, "https://github.com/benoitc/hackney.git",
-                     {tag, "1.4.4"}}}
+                     {tag, "1.6.1"}}}
 ],
 
 case IsRebar3 of

--- a/src/couchbeam.erl
+++ b/src/couchbeam.erl
@@ -105,8 +105,7 @@ server_connection(Host, Port) when is_integer(Port) ->
 %%          {proxy_password, string()}         |
 %%          {basic_auth, {username(), password()}} |
 %%          {cookie, string()}                 |
-%%          {oauth, oauthOptions()}            |
-%%          {proxyauth, [proxyauthOpt]}
+%%          {oauth, oauthOptions()}
 %%
 %% username() = string()
 %% password() = string()
@@ -119,13 +118,6 @@ server_connection(Host, Port) when is_integer(Port) ->
 %%          {consumer_secret, string()} |
 %%          {signature_method, string()}
 %%
-%% proxyOpt = {X-Auth-CouchDB-UserName, username :: string()} |
-%%            {X-Auth-CouchDB-Roles, roles :: string} | list_of_user_roles_separated_by_a_comma
-%%            {X-Auth-CouchDB-Token: token :: string()} | authentication token. Optional, but strongly recommended to force token be required to prevent requests from untrusted sources.
-
-
-
-
 server_connection(Host, Port, Prefix, Options)
         when is_integer(Port), Port =:= 443 ->
     BaseUrl = iolist_to_binary(["https://", Host, ":",

--- a/src/couchbeam.erl
+++ b/src/couchbeam.erl
@@ -105,7 +105,8 @@ server_connection(Host, Port) when is_integer(Port) ->
 %%          {proxy_password, string()}         |
 %%          {basic_auth, {username(), password()}} |
 %%          {cookie, string()}                 |
-%%          {oauth, oauthOptions()}
+%%          {oauth, oauthOptions()}            |
+%%          {proxyauth, [proxyauthOpt]}
 %%
 %% username() = string()
 %% password() = string()
@@ -118,6 +119,13 @@ server_connection(Host, Port) when is_integer(Port) ->
 %%          {consumer_secret, string()} |
 %%          {signature_method, string()}
 %%
+%% proxyOpt = {X-Auth-CouchDB-UserName, username :: string()} |
+%%            {X-Auth-CouchDB-Roles, roles :: string} | list_of_user_roles_separated_by_a_comma
+%%            {X-Auth-CouchDB-Token: token :: string()} | authentication token. Optional, but strongly recommended to force token be required to prevent requests from untrusted sources.
+
+
+
+
 server_connection(Host, Port, Prefix, Options)
         when is_integer(Port), Port =:= 443 ->
     BaseUrl = iolist_to_binary(["https://", Host, ":",

--- a/src/couchbeam_changes_stream.erl
+++ b/src/couchbeam_changes_stream.erl
@@ -105,7 +105,7 @@ do_init_stream(#state{mref=MRef,
                       feed_type=FeedType}=State) ->
     #db{server=Server, options=ConnOpts} = Db,
     %% we are doing the request asynchronously
-    ConnOpts1 = [{async, once} | ConnOpts],
+    ConnOpts1 = [{async, once} | ConnOpts] ++ Server#server.options,
 
     %% if we are filtering the changes using docids, send a POST request
     %% instead of a GET to make sure it will be accepted whatever the

--- a/src/couchbeam_changes_stream.erl
+++ b/src/couchbeam_changes_stream.erl
@@ -238,27 +238,42 @@ wait_reconnect(#state{parent=Parent,
     end.
 
 
-decode_data(Data, #state{owner=Owner,
-                         ref=Ref,
-                         feed_type=continuous,
-                         decoder=DecodeFun}=State) ->
+seq(Props,#state{owner=Owner,ref=Ref}) ->
+  Seq = couchbeam_util:get_value(<<"seq">>, Props),
+  put(last_seq, Seq),
+  Owner ! {Ref, {change, {Props}}}.
 
-    {incomplete, DecodeFun2} = try DecodeFun of
-        nil ->
-            post_decode(jsx:decode(Data, [stream]));
-        _ ->
-            DecodeFun(Data)
+decode(Data) ->
+  jsx:decode(Data,[return_tail,stream]).
+
+decodefun(nil) ->
+  fun(Data) -> decode(Data) end;
+decodefun(Fun) ->
+  Fun.
+
+decode_with_tail(Data, Fun, State) ->
+  case (decodefun(Fun))(Data) of
+    {with_tail,Props,Rest} ->
+      seq(Props,State),
+      decode_with_tail(Rest,decodefun(nil),State);
+    Other -> Other
+  end.
+
+decode_data(Data, #state{feed_type=continuous,
+  decoder=DecodeFun}=State) ->
+
+  {incomplete, DecodeFun2} =
+    try
+      decode_with_tail(Data,DecodeFun,State)
     catch error:badarg -> exit(badarg)
     end,
 
-    try DecodeFun2(end_stream) of
-        Props ->
-            Seq = couchbeam_util:get_value(<<"seq">>, Props),
-            put(last_seq, Seq),
-            Owner ! {Ref, {change, {Props}}},
-            maybe_continue(State#state{decoder=nil})
-    catch error:badarg -> maybe_continue(State#state{decoder=DecodeFun2})
-    end;
+  try DecodeFun2(end_stream) of
+    Props ->
+      seq(Props,State),
+      maybe_continue(State#state{decoder=nil})
+  catch error:badarg -> maybe_continue(State#state{decoder=DecodeFun2})
+  end;
 decode_data(Data, #state{client_ref=ClientRef,
                          decoder=DecodeFun}=State) ->
     try 

--- a/src/couchbeam_changes_stream.erl
+++ b/src/couchbeam_changes_stream.erl
@@ -126,11 +126,11 @@ do_init_stream(#state{mref=MRef,
 
     {ok, ClientRef} = case DocIds of
         [] ->
-            hackney:request(get, Url, [], <<>>, ConnOpts1);
+            couchbeam_httpc:request(get, Url, [], <<>>, ConnOpts1);
         DocIds ->
             Body =  couchbeam_ejson:encode({[{<<"doc_ids">>, DocIds}]}),
             Headers = [{<<"Content-Type">>, <<"application/json">>}],
-            hackney:request(post, Url, Headers, Body, ConnOpts1)
+            couchbeam_httpc:request(post, Url, Headers, Body, ConnOpts1)
     end,
     receive
         {'DOWN', MRef, _, _, _} ->

--- a/src/couchbeam_changes_stream.erl
+++ b/src/couchbeam_changes_stream.erl
@@ -105,7 +105,7 @@ do_init_stream(#state{mref=MRef,
                       feed_type=FeedType}=State) ->
     #db{server=Server, options=ConnOpts} = Db,
     %% we are doing the request asynchronously
-    ConnOpts1 = [{async, once} | ConnOpts] ++ Server#server.options,
+    ConnOpts1 = [{async, once} | ConnOpts],
 
     %% if we are filtering the changes using docids, send a POST request
     %% instead of a GET to make sure it will be accepted whatever the

--- a/src/couchbeam_httpc.erl
+++ b/src/couchbeam_httpc.erl
@@ -42,9 +42,7 @@ make_headers(Method, Url, Headers, Options) ->
         _ ->
             Headers
     end,
-   {Headers2, Options1} = maybe_oauth_header(Method, Url, Headers1, Options),
-   maybe_proxyauth_header(Headers2, Options1).
-
+    maybe_oauth_header(Method, Url, Headers1, Options).
 
 maybe_oauth_header(Method, Url, Headers, Options) ->
     case couchbeam_util:get_value(oauth, Options) of
@@ -54,14 +52,6 @@ maybe_oauth_header(Method, Url, Headers, Options) ->
             Hdr = couchbeam_util:oauth_header(Url, Method, OauthProps),
             {[Hdr|Headers], proplists:delete(oauth, Options)}
     end.
-
-maybe_proxyauth_header(Headers, Options) ->
-  case couchbeam_util:get_value(proxyauth, Options) of
-    undefined ->
-      {Headers, Options};
-    ProxyauthProps ->
-      {lists:append([ProxyauthProps,Headers]), proplists:delete(proxyauth, Options)}
-  end.
 
 db_resp({ok, Ref}=Resp, _Expect) when is_reference(Ref) ->
     Resp;

--- a/src/couchbeam_httpc.erl
+++ b/src/couchbeam_httpc.erl
@@ -42,7 +42,9 @@ make_headers(Method, Url, Headers, Options) ->
         _ ->
             Headers
     end,
-    maybe_oauth_header(Method, Url, Headers1, Options).
+   {Headers2, Options1} = maybe_oauth_header(Method, Url, Headers1, Options),
+   maybe_proxyauth_header(Headers2, Options1).
+
 
 maybe_oauth_header(Method, Url, Headers, Options) ->
     case couchbeam_util:get_value(oauth, Options) of
@@ -52,6 +54,14 @@ maybe_oauth_header(Method, Url, Headers, Options) ->
             Hdr = couchbeam_util:oauth_header(Url, Method, OauthProps),
             {[Hdr|Headers], proplists:delete(oauth, Options)}
     end.
+
+maybe_proxyauth_header(Headers, Options) ->
+  case couchbeam_util:get_value(proxyauth, Options) of
+    undefined ->
+      {Headers, Options};
+    ProxyauthProps ->
+      {lists:append([ProxyauthProps,Headers]), proplists:delete(proxyauth, Options)}
+  end.
 
 db_resp({ok, Ref}=Resp, _Expect) when is_reference(Ref) ->
     Resp;

--- a/src/couchbeam_httpc.erl
+++ b/src/couchbeam_httpc.erl
@@ -42,8 +42,8 @@ make_headers(Method, Url, Headers, Options) ->
         _ ->
             Headers
     end,
-    Headers2 = maybe_oauth_header(Method, Url, Headers1, Options),
-    maybe_proxyauth_header(Headers2, Options).
+   {Headers2, Options1} = maybe_oauth_header(Method, Url, Headers1, Options),
+   maybe_proxyauth_header(Headers2, Options1).
 
 
 maybe_oauth_header(Method, Url, Headers, Options) ->

--- a/src/couchbeam_httpc.erl
+++ b/src/couchbeam_httpc.erl
@@ -42,7 +42,9 @@ make_headers(Method, Url, Headers, Options) ->
         _ ->
             Headers
     end,
-    maybe_oauth_header(Method, Url, Headers1, Options).
+    Headers2 = maybe_oauth_header(Method, Url, Headers1, Options),
+    maybe_proxyauth_header(Headers2, Options).
+
 
 maybe_oauth_header(Method, Url, Headers, Options) ->
     case couchbeam_util:get_value(oauth, Options) of
@@ -52,6 +54,14 @@ maybe_oauth_header(Method, Url, Headers, Options) ->
             Hdr = couchbeam_util:oauth_header(Url, Method, OauthProps),
             {[Hdr|Headers], proplists:delete(oauth, Options)}
     end.
+
+maybe_proxyauth_header(Headers, Options) ->
+  case couchbeam_util:get_value(proxyauth, Options) of
+    undefined ->
+      {Headers, Options};
+    ProxyauthProps ->
+      {lists:append([ProxyauthProps,Headers]), proplists:delete(proxyauth, Options)}
+  end.
 
 db_resp({ok, Ref}=Resp, _Expect) when is_reference(Ref) ->
     Resp;

--- a/src/couchbeam_util.erl
+++ b/src/couchbeam_util.erl
@@ -20,7 +20,6 @@
 -export([start_app_deps/1, get_app_env/2]).
 -export([encode_docid1/1, encode_docid_noop/1]).
 -export([force_param/3]).
--export([proxy_token/2, proxy_header/3]).
 
 
 
@@ -77,10 +76,12 @@ encode_query_value(K, V) when is_binary(K) ->
 encode_query_value(_K, V) -> V.
 
 % build oauth header
+oauth_header(Url, Action, OauthProps) when is_binary(Url) ->
+    oauth_header(binary_to_list(Url),Action, OauthProps);
 oauth_header(Url, Action, OauthProps) ->
     #hackney_url{qs=QS} = hackney_url:parse_url(Url),
     QSL = [{binary_to_list(K), binary_to_list(V)} || {K,V} <-
-                                                     hackney_url:qs(QS)],
+                                                     hackney_url:parse_qs(QS)],
 
     % get oauth paramerers
     ConsumerKey = to_list(get_value(consumer_key, OauthProps)),

--- a/src/couchbeam_util.erl
+++ b/src/couchbeam_util.erl
@@ -20,7 +20,7 @@
 -export([start_app_deps/1, get_app_env/2]).
 -export([encode_docid1/1, encode_docid_noop/1]).
 -export([force_param/3]).
--export([proxy_token/2]).
+-export([proxy_token/2, proxy_header/3]).
 
 
 
@@ -254,6 +254,15 @@ get_app_env(Env, Default) ->
         {ok, Val} -> Val;
         undefined -> Default
     end.
+
+proxy_header(UserName,Roles,{secret,Secret}) ->
+    proxy_header(UserName,Roles,proxy_token(Secret,UserName));
+
+proxy_header(UserName,Roles,Token) ->
+[{<<"X-Auth-CouchDB-UserName">>, UserName},
+    {<<"X-Auth-CouchDB-Roles">>, Roles},
+    {<<"X-Auth-CouchDB-Token">>, Token}
+].
 
 proxy_token(Secret,UserName) ->
     hackney_bstr:to_hex(hmac(sha, Secret, UserName)).

--- a/src/couchbeam_util.erl
+++ b/src/couchbeam_util.erl
@@ -20,6 +20,7 @@
 -export([start_app_deps/1, get_app_env/2]).
 -export([encode_docid1/1, encode_docid_noop/1]).
 -export([force_param/3]).
+-export([proxy_token/2]).
 
 
 
@@ -252,4 +253,17 @@ get_app_env(Env, Default) ->
     case application:get_env(couchbeam, Env) of
         {ok, Val} -> Val;
         undefined -> Default
+    end.
+
+proxy_token(Secret,UserName) ->
+    hackney_bstr:to_hex(hmac(sha, Secret, UserName)).
+
+hmac(Alg, Key, Data) ->
+    case {Alg, erlang:function_exported(crypto, hmac, 3)} of
+        {_, true} ->
+            crypto:hmac(Alg, Key, Data);
+        {sha, false} ->
+            crypto:sha_mac(Key, Data);
+        {Alg, false} ->
+            throw({unsupported, Alg})
     end.

--- a/src/couchbeam_uuids.erl
+++ b/src/couchbeam_uuids.erl
@@ -32,7 +32,7 @@ random() ->
 %% @doc return a random uuid based on time
 -spec utc_random() -> binary().
 utc_random() ->
-    utc_suffix(couch_util:to_hex(crypto:rand_bytes(9))).
+    utc_suffix(hackney_bstr:to_hex(crypto:rand_bytes(9))).
 
 %% @doc Get a list of uuids from the server
 %% @spec get_uuids(server(), integer()) -> lists()

--- a/src/couchbeam_view_stream.erl
+++ b/src/couchbeam_view_stream.erl
@@ -84,7 +84,7 @@ init_stream(Parent, Owner, StreamRef, {_Db, _Url, _Args}=Req,
     erlang:demonitor(MRef),
     ok.
 
-do_init_stream({#db{options=Opts, server = Server}, Url, Args}, #state{mref=MRef}=State) ->
+do_init_stream({#db{options=Opts}, Url, Args}, #state{mref=MRef}=State) ->
     %% we are doing the request asynchronously
     FinalOpts = [{async, once} | Opts],
     Reply = case Args#view_query_args.method of

--- a/src/couchbeam_view_stream.erl
+++ b/src/couchbeam_view_stream.erl
@@ -86,7 +86,7 @@ init_stream(Parent, Owner, StreamRef, {_Db, _Url, _Args}=Req,
 
 do_init_stream({#db{options=Opts, server = Server}, Url, Args}, #state{mref=MRef}=State) ->
     %% we are doing the request asynchronously
-    FinalOpts = [{async, once} | Opts] ++ Server#server.options,
+    FinalOpts = [{async, once} | Opts],
     Reply = case Args#view_query_args.method of
         get ->
             couchbeam_httpc:request(get, Url, [], <<>>, FinalOpts);

--- a/src/couchbeam_view_stream.erl
+++ b/src/couchbeam_view_stream.erl
@@ -89,12 +89,12 @@ do_init_stream({#db{options=Opts}, Url, Args}, #state{mref=MRef}=State) ->
     FinalOpts = [{async, once} | Opts],
     Reply = case Args#view_query_args.method of
         get ->
-            hackney:request(get, Url, [], <<>>, FinalOpts);
+          couchbeam_httpc:request(get, Url, [], <<>>, FinalOpts);
         post ->
             Body = couchbeam_ejson:encode({[{<<"keys">>,
                                              Args#view_query_args.keys}]}),
             Headers = [{<<"Content-Type">>, <<"application/json">>}],
-            hackney:request(post, Url, Headers, Body, FinalOpts)
+            couchbeam_httpc:request(post, Url, Headers, Body, FinalOpts)
     end,
 
     case Reply of

--- a/src/couchbeam_view_stream.erl
+++ b/src/couchbeam_view_stream.erl
@@ -84,12 +84,12 @@ init_stream(Parent, Owner, StreamRef, {_Db, _Url, _Args}=Req,
     erlang:demonitor(MRef),
     ok.
 
-do_init_stream({#db{options=Opts}, Url, Args}, #state{mref=MRef}=State) ->
+do_init_stream({#db{options=Opts, server = Server}, Url, Args}, #state{mref=MRef}=State) ->
     %% we are doing the request asynchronously
-    FinalOpts = [{async, once} | Opts],
+    FinalOpts = [{async, once} | Opts] ++ Server#server.options,
     Reply = case Args#view_query_args.method of
         get ->
-          couchbeam_httpc:request(get, Url, [], <<>>, FinalOpts);
+            couchbeam_httpc:request(get, Url, [], <<>>, FinalOpts);
         post ->
             Body = couchbeam_ejson:encode({[{<<"keys">>,
                                              Args#view_query_args.keys}]}),


### PR DESCRIPTION
CouchDb 2.0 compatible:

1) _changes feed gives more than one row
2) added oauth and proxyauth using couchbeam_httpc:request instead of hackney:request
3) some fixes like hackney_url:qs instead of hackney_url:parse_qs