### PR TITLE
fixing incorrect mix.exs versions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ use Mix.Project
     def project do
         [
             app: :couchbeam,
-            version: "1.4.0",
+            version: "1.4.1",
             description: "Erlang CouchDB client",
             deps: deps,
             package: package,
@@ -33,7 +33,7 @@ use Mix.Project
 
     def deps do
         [
-            {:hackney, "~> 1.6.2"},
+            {:hackney, "~> 1.6"},
             {:jsx, "~> 2.8.0"}
         ]
     end

--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ use Mix.Project
             app: :couchbeam,
             version: "1.4.1",
             description: "Erlang CouchDB client",
-            deps: deps,
-            package: package,
+            deps: deps(),
+            package: package(),
             language: :erlang
         ]
     end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
-%{"certifi": {:hex, :certifi, "0.4.0"},
-  "hackney": {:hex, :hackney, "1.5.7"},
-  "idna": {:hex, :idna, "1.2.0"},
-  "jsx": {:hex, :jsx, "2.8.0"},
-  "metrics": {:hex, :metrics, "1.0.1"},
-  "mimerl": {:hex, :mimerl, "1.0.2"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0"}}
+%{"certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
+  "hackney": {:hex, :hackney, "1.6.3", "d489d7ca2d4323e307bedc4bfe684323a7bf773ecfd77938f3ee8074e488e140", [:mix, :rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
+  "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
+  "jsx": {:hex, :jsx, "2.8.0", "749bec6d205c694ae1786d62cea6cc45a390437e24835fd16d12d74f07097727", [:mix, :rebar], []},
+  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []}}


### PR DESCRIPTION
## Fixes

* The mix.exs version reported for couchbeam was 1.4.0. Updated to 1.4.1.
* hackney dependency wouldn't pick up 1.6.3. Changed hackney reference to "\~> 1.6". The "\~>" operator says get 1.6.0 and up (1.6.1, 1.6.2..., but not 1.7.x). This assumes you are following semantic versioning where the point release is only for bug fixes or new features, but no breaking changes.
* The mix.lock file wasn't included correctly and referenced a very old hackney release.

## Steps for working with mix

* mix deps.clean --all
* mix deps.get
* mix compile

Note: these can all be wrapped up in one command like so...

* mix do deps.clean --all, deps.get, compile