### PR TITLE
added support for _design document _list functions

### DIFF
--- a/src/couchbeam_view.erl
+++ b/src/couchbeam_view.erl
@@ -420,16 +420,23 @@ parse_view_options([_|Rest], Args) ->
 
 make_view(#db{server=Server}=Db, ViewName, Options, Fun) ->
     Args = parse_view_options(Options),
+    ListName = proplists:get_value(list, Options),
     case ViewName of
         'all_docs' ->
             Url = hackney_url:make_url(couchbeam_httpc:server_url(Server),
                                        [couchbeam_httpc:db_url(Db), <<"_all_docs">>],
                                        Args#view_query_args.options),
             Fun(Args, Url);
-        {DName, VName} ->
+        {DName, VName} when ListName =:= 'undefined' ->
             Url = hackney_url:make_url(couchbeam_httpc:server_url(Server),
                                        [couchbeam_httpc:db_url(Db), <<"_design">>,
                                         DName, <<"_view">>, VName],
+                                       Args#view_query_args.options),
+            Fun(Args, Url);
+        {DName, VName} ->
+            Url = hackney_url:make_url(couchbeam_httpc:server_url(Server),
+                                       [couchbeam_httpc:db_url(Db), <<"_design">>,
+                                        DName, <<"_list">>, ListName, VName],
                                        Args#view_query_args.options),
             Fun(Args, Url);
         _ ->


### PR DESCRIPTION
The library current accepts a view option 'list' which is passed along to couchdb:
https://github.com/benoitc/couchbeam/blob/master/src/couchbeam_view.erl#L406

However, unless I am misunderstanding the documentation it should be changing the URL to support _list requests.  This PR will do just that and has been tested on BigCouch (which should have the same _list API as CouchDB).  The parameter did not seem to have any impact prior to this change.

Thanks!
