### PR TITLE
Add mix building back

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,60 @@
+defmodule Couchbeam.Mixfile do
+use Mix.Project
+
+    def project do
+        [
+            app: :couchbeam,
+            version: "1.4.0",
+            description: "Erlang CouchDB client",
+            deps: deps,
+            package: package,
+            language: :erlang
+        ]
+    end
+
+    def application do
+        [
+            applications:
+                [
+                    :kernel,
+                    :stdlib,
+                    :crypto,
+                    :asn1,
+                    :public_key,
+                    :ssl,
+                    :hackney
+                ],
+            env:
+                [
+                ],
+            mod: {:couchbeam_app, []}
+        ]
+    end
+
+    def deps do
+        [
+            {:hackney, "~> 1.6.2"},
+            {:jsx, "~> 2.8.0"}
+        ]
+    end
+
+    defp package do
+        [
+            files: [
+                "src",
+                "include",
+                "mix.exs",
+                "mix.lock",
+                "rebar.config",
+                "rebar.lock",
+                "README.md",
+                "NEWS.md",
+                "LICENSE",
+                "NOTICE"
+            ],
+            maintainers: ["Benoit Chesneau"],
+            licenses: ["MIT"],
+            links: %{"Github" => "https://github.com/benoitc/couchbeam"}
+        ]
+    end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ use Mix.Project
     def project do
         [
             app: :couchbeam,
-            version: "1.4.0",
+            version: "1.4.2",
             description: "Erlang CouchDB client",
             deps: deps,
             package: package,

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,7 @@
+%{"certifi": {:hex, :certifi, "0.4.0"},
+  "hackney": {:hex, :hackney, "1.5.7"},
+  "idna": {:hex, :idna, "1.2.0"},
+  "jsx": {:hex, :jsx, "2.8.0"},
+  "metrics": {:hex, :metrics, "1.0.1"},
+  "mimerl": {:hex, :mimerl, "1.0.2"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0"}}

--- a/src/couchbeam.app.src
+++ b/src/couchbeam.app.src
@@ -29,11 +29,14 @@
   {files, [
     "src",
     "include",
+    "mix.exs",
+    "mix.lock",
     "rebar.config",
     "rebar.lock",
     "README.md",
     "NEWS.md",
     "LICENSE",
-    "NOTICE"]}
+    "NOTICE"]},
+  {build_tools, [<<"rebar3">>, <<"mix">>]}
  ]
 }.


### PR DESCRIPTION
As expressed in #167, Elixir users are getting dependency issues when no mix.exs file exists specifying the required dependencies.