### PR TITLE
Fix some dialyzer errors

### DIFF
--- a/include/couchbeam.hrl
+++ b/include/couchbeam.hrl
@@ -112,7 +112,7 @@
 % record to keep database information
 -record(db, {
     server :: server(),
-    name :: string(),
+    name :: binary(),
     options = [] :: list()
 }).
 

--- a/src/couchbeam_view.erl
+++ b/src/couchbeam_view.erl
@@ -81,7 +81,7 @@ stream(Db, ViewName) ->
 
 -spec stream(Db::db(), ViewName::'all_docs' | {DesignName::string(),
         ViewName::string()}, Options::view_options())
-    -> {ok, StartRef::term(), ViewPid::pid()} | {error, term()}.
+    -> {ok, StartRef::term()} | {error, term()}.
 %% @doc stream view results to a pid
 %%  <p>Db: a db record</p>
 %%  <p>ViewName: 'all_docs' to get all docs or {DesignName,


### PR DESCRIPTION
## Problem

We are running our CI system configured to fail the build when `dialyzer` emits warnings.
Recently we added `couchbeam` as a dependency and starting seeing new errors on the methods that used it.

- `has no local return` initially
- `The pattern {'ok', _results@1} can never match the type {'error',_} | {'ok',_,pid()}` after that 

## Solution

- Update the typing for `#db{name}` from `string` to `binary`  (fix in first commit)
- Update the type of `couch_beam_view:stream` by removing the third element (`ViewPid::pid`) (fix in the second commit)

There are a few other dialyzer errors remaining, but since those have not (yet) propagated to our code, they are not fixed by this PR (we will be paying attention and submitting new PRs if/when needed).

## Dialyzer output

### Before
```
couchbeam.erl:79: The call couchbeam:server_connection(Host::any(),Port::integer(),[],[]) will never return since it differs in the 3rd argument from the success typing arguments: (binary() | maybe_improper_list(any(),binary() | []) | byte(),integer(),binary(),[any()])
couchbeam.erl:91: Invalid type specification for function couchbeam:server_connection/4. The success typing is (binary() | maybe_improper_list(any(),binary() | []) | byte(),integer(),binary(),[any()]) -> #server{url::binary(),options::[any()]}
couchbeam.erl:243: Function design_info/2 has no local return
couchbeam.erl:256: Function view_cleanup/1 has no local return
couchbeam.erl:310: Record construction #db{server::#server{options::[any()]},name::binary(),options::[{_,_}]} violates the declared type of field name::string()
couchbeam.erl:319: Function open_db/2 has no local return
couchbeam.erl:325: Function open_db/3 has no local return
couchbeam.erl:327: Record construction #db{server::#server{options::[any()]},name::binary(),options::[]} violates the declared type of field name::string()
couchbeam.erl:466: Invalid type specification for function couchbeam:end_doc_stream/1. The success typing is ({reference() | {'client',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_},_}) -> 'ok' | 'req_not_found' | {'client',_,_,_,_,_,_,_,'nil',_,_,_,_,_,_,_,_,_,_,_,_,'closed',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}
couchbeam.erl:526: Invalid type specification for function couchbeam:save_doc/4. The success typing is (#db{server::#server{options::[any()]},name::string(),options::[any()]},{[any()]},[any()],binary() | [{binary(),binary()}]) -> any()
couchbeam.erl:579: Function delete_doc/2 has no local return
couchbeam.erl:587: Function delete_doc/3 has no local return
couchbeam.erl:592: Function delete_docs/2 has no local return
couchbeam.erl:600: Function delete_docs/3 has no local return
couchbeam.erl:621: Function save_docs/2 has no local return
couchbeam.erl:626: Function save_docs/3 has no local return
couchbeam.erl:731: Function fetch_attachment/3 has no local return
couchbeam.erl:745: Function fetch_attachment/4 has no local return
couchbeam.erl:809: Function put_attachment/4 has no local return
couchbeam.erl:822: Function put_attachment/5 has no local return
couchbeam.erl:924: Function ensure_full_commit/1 has no local return
couchbeam.erl:931: Function ensure_full_commit/2 has no local return
couchbeam.erl:948: Function compact/1 has no local return
couchbeam.erl:964: Function compact/2 has no local return
couchbeam.erl:983: Function get_missing_revs/2 has no local return
couchbeam_changes.erl:205: Function changes_request/2 has no local return
couchbeam_changes_stream.erl:48: Function init_stream/5 has no local return
couchbeam_changes_stream.erl:102: Function do_init_stream/1 has no local return
couchbeam_changes_stream.erl:283: The pattern {'ok', _} can never match the type 'ok' | {'error',_}
couchbeam_changes_stream.erl:561: Function post_decode/1 will never be called
couchbeam_httpc.erl:179: The pattern 'mp_mixed' can never match the type 'eof' | {'error',_}
couchbeam_httpc.erl:183: The pattern 'mp_mixed_eof' can never match the type 'eof' | {'error',_}
couchbeam_httpc.erl:222: The pattern 'mp_mixed_eof' can never match the type 'eof' | {'error',_}
couchbeam_util.erl:288: The pattern {_, 'false'} can never match since previous clauses completely covered the type {'sha',boolean()}
couchbeam_view.erl:68: The pattern {'ok', Ref} can never match the type {'error','invalid_view_name'}
couchbeam_view.erl:298: The pattern {'ok', Ref} can never match the type {'error','invalid_view_name'}
couchbeam_view.erl:439: Function fold_view_results/3 will never be called
couchbeam_view.erl:458: Function collect_view_results/2 will never be called
couchbeam_view_stream.erl:168: The pattern {'ok', _} can never match the type 'ok' | {'error',_}
```

### After
```
couchbeam.erl:79: The call couchbeam:server_connection(Host::any(),Port::integer(),[],[]) will never return since it differs in the 3rd argument from the success typing arguments: (binary() | maybe_improper_list(any(),binary() | []) | byte(),integer(),binary(),[any()])
couchbeam.erl:91: Invalid type specification for function couchbeam:server_connection/4. The success typing is (binary() | maybe_improper_list(any(),binary() | []) | byte(),integer(),binary(),[any()]) -> #server{url::binary(),options::[any()]}
couchbeam.erl:466: Invalid type specification for function couchbeam:end_doc_stream/1. The success typing is ({reference() | {'client',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_},_}) -> 'ok' | 'req_not_found' | {'client',_,_,_,_,_,_,_,'nil',_,_,_,_,_,_,_,_,_,_,_,_,'closed',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}
couchbeam.erl:526: Invalid type specification for function couchbeam:save_doc/4. The success typing is (#db{server::#server{options::[any()]},name::binary(),options::[any()]},{[any()]},[any()],binary() | [{binary(),binary()}]) -> any()
couchbeam.erl:742: Invalid type specification for function couchbeam:fetch_attachment/4. The success typing is (#db{server::#server{options::[any()]},name::binary(),options::[any()]},binary() | maybe_improper_list(binary() | maybe_improper_list(any(),binary() | []) | byte(),binary() | []),binary(),[any()]) -> {'error',_} | {'ok',_} | {'ok',integer(),[any()]} | {'ok',integer(),[any()],_}
couchbeam.erl:809: Function put_attachment/4 has no local return
couchbeam.erl:822: Function put_attachment/5 has no local return
couchbeam_changes_stream.erl:283: The pattern {'ok', _} can never match the type 'ok' | {'error',_}
couchbeam_changes_stream.erl:561: Function post_decode/1 will never be called
couchbeam_httpc.erl:179: The pattern 'mp_mixed' can never match the type 'eof' | {'error',_}
couchbeam_httpc.erl:183: The pattern 'mp_mixed_eof' can never match the type 'eof' | {'error',_}
couchbeam_httpc.erl:222: The pattern 'mp_mixed_eof' can never match the type 'eof' | {'error',_}
couchbeam_util.erl:288: The pattern {_, 'false'} can never match since previous clauses completely covered the type {'sha',boolean()}
couchbeam_view_stream.erl:168: The pattern {'ok', _} can never match the type 'ok' | {'error',_}
```