### PR TITLE
Fix references to couchbeam_view_sup registered name

### DIFF
--- a/src/couchbeam_changes.erl
+++ b/src/couchbeam_changes.erl
@@ -158,9 +158,9 @@ follow_once(Db, Options) ->
 
 cancel_stream(Ref) ->
     with_changes_stream(Ref, fun(Pid) ->
-                case supervisor:terminate_child(couch_view_sup, Pid) of
+                case supervisor:terminate_child(couchbeam_view_sup, Pid) of
                     ok ->
-                        case supervisor:delete_child(couch_view_sup, Pid) of
+                        case supervisor:delete_child(couchbeam_view_sup, Pid) of
                             ok ->ok;
                             {error, not_found} -> ok;
                             Error -> Error

--- a/src/couchbeam_view.erl
+++ b/src/couchbeam_view.erl
@@ -167,9 +167,9 @@ stream(Db, ViewName, Options) ->
 
 cancel_stream(Ref) ->
     with_view_stream(Ref, fun(Pid) ->
-                case supervisor:terminate_child(couch_view_sup, Pid) of
+                case supervisor:terminate_child(couchbeam_view_sup, Pid) of
                     ok ->
-                        case supervisor:delete_child(couch_view_sup,
+                        case supervisor:delete_child(couchbeam_view_sup,
                                                      Pid) of
                             ok ->
                                 ok;


### PR DESCRIPTION
I was seeing some crashes when calling `gen_changes:stop(pid)` on my `gen_changes` implementation, it appears that calls to the registered name for the view supervisor need to be changed slightly to match the module name.