### PR TITLE
Support _find query

### DIFF
--- a/src/couchbeam.erl
+++ b/src/couchbeam.erl
@@ -1010,7 +1010,9 @@ find_docs(#db{server=Server, options=Opts}=Db, Query, Params) ->
     Url = hackney_url:make_url(couchbeam_httpc:server_url(Server), 
         [couchbeam_httpc:db_url(Db), <<"_find">>],
         Params),
-    case couchbeam_httpc:db_request(post, Url, [], couchbeam_ejson:encode(Query), Opts,
+    Headers = [ {<<"content-type">>, <<"application/json">>}, 
+                {<<"accept">>, <<"application/json">>} ],
+    case couchbeam_httpc:db_request(post, Url, Headers, couchbeam_ejson:encode(Query), Opts,
                                     [200, 201]) of
         {ok, _, RespHeaders, Ref} ->
             case hackney_headers:parse(<<"content-type">>, RespHeaders) of

--- a/src/couchbeam.erl
+++ b/src/couchbeam.erl
@@ -1008,7 +1008,7 @@ get_missing_revs(#db{server=Server, options=Opts}=Db, IdRevs) ->
 
 find_docs(#db{server=Server, options=Opts}=Db, Selector, Params) ->
     Url = hackney_url:make_url(couchbeam_httpc:server_url(Server), 
-        [couchbeam_httpc:db_url(Db), <<"_find">>]),
+        [couchbeam_httpc:db_url(Db), <<"_find">>], []),
     Headers = [ {<<"content-type">>, <<"application/json">>}, 
                 {<<"accept">>, <<"application/json">>} ],
     BodyJson = {[{selector, Selector} | Params]},

--- a/src/couchbeam.erl
+++ b/src/couchbeam.erl
@@ -1006,13 +1006,13 @@ get_missing_revs(#db{server=Server, options=Opts}=Db, IdRevs) ->
             Error
     end.
 
-find_docs(#db{server=Server, options=Opts}=Db, Query, Params) ->
+find_docs(#db{server=Server, options=Opts}=Db, Selector, Params) ->
     Url = hackney_url:make_url(couchbeam_httpc:server_url(Server), 
-        [couchbeam_httpc:db_url(Db), <<"_find">>],
-        Params),
+        [couchbeam_httpc:db_url(Db), <<"_find">>]),
     Headers = [ {<<"content-type">>, <<"application/json">>}, 
                 {<<"accept">>, <<"application/json">>} ],
-    case couchbeam_httpc:db_request(post, Url, Headers, couchbeam_ejson:encode(Query), Opts,
+    BodyJson = {[{selector, Selector} | Params]},
+    case couchbeam_httpc:db_request(post, Url, Headers, couchbeam_ejson:encode(BodyJson), Opts,
                                     [200, 201]) of
         {ok, _, RespHeaders, Ref} ->
             case hackney_headers:parse(<<"content-type">>, RespHeaders) of


### PR DESCRIPTION
Closes #185 
Adds support for _find using mango queries https://docs.couchdb.org/en/2.3.1/api/database/find.html

Usage:
```erlang
couchbeam:find_docs(Db, {[
    {<<"$or">>, [
      {[{<<"salutation">>, {[{<<"$regex">>, <<"Test">>}]}}]},
      {[{<<"forename">>, {[{<<"$regex">>, <<"Test">>}]}}]},
      {[{<<"surname">>, {[{<<"$regex">>, <<"Test">>}]}}]}
    ]},
    {<<"company">>, {[{<<"$eq">>, <<"08f878d42296b9f9115848ce01012847">>}]}},
    {<<"type">>, {[{<<"$eq">>, <<"contact">>}]}}
  ]}, [{limit, 10}, {skip, 5}]).
```