### PR TITLE
Convert att_name to format expected by hackney_url:make_url

### DIFF
--- a/src/couchbeam_util.erl
+++ b/src/couchbeam_util.erl
@@ -42,7 +42,7 @@ encode_att_name(Name) ->
     Parts = lists:foldl(fun(P, Att) ->
                [xmerl_ucs:to_utf8(P)|Att]
        end, [], string:tokens(Name, "/")),
-    lists:flatten(Parts).
+    ?MODULE:to_binary(lists:flatten(Parts)).
 
 encode_docid(DocId) when is_list(DocId) ->
     encode_docid(list_to_binary(DocId));


### PR DESCRIPTION
Where `encode_att_name` is used (couchbeam.erl L846), the expected type is a binary, not a list, so convert the return value to a binary.