### PR TITLE
Fix condition that may cause persistent CLOSE-WAIT sockets

### DIFF
--- a/src/couchbeam_view_stream.erl
+++ b/src/couchbeam_view_stream.erl
@@ -100,6 +100,10 @@ do_init_stream({#db{options=Opts}, Url, Args}, #state{mref=MRef}=State) ->
 
     case Reply of
         {ok, Ref} ->
+            State = hackney:request_info(Ref),
+            Mod = proplists:get_value(transport, State),
+            S = proplists:get_value(socket, State),
+            Mod:controlling_process(S, self()),
             receive
                 {'DOWN', MRef, _, _, _} ->
                     %% parent exited there is no need to continue


### PR DESCRIPTION
By transferring control to couchbeam_view_stream process, we ensure that the socket is effectively closed on both sides, even in case of crashes or stop of  this process. In some cases increasing numbers of sockets in CLOSE-WAIT state was observed.